### PR TITLE
Feat/scan params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions/setup-rust@v1
+      with:
+        rust-version: stable
+
+    - name: Build project
+      run: cargo build --verbose
+    
+    - name: Run cargo check
+      run: cargo check --all
+
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,22 @@
-name: CI
+name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-
-    - name: Set up Rust
-      uses: actions/setup-rust@v1
-      with:
-        rust-version: stable
-
-    - name: Build project
+    - uses: actions/checkout@v4
+    - name: Build
       run: cargo build --verbose
-    
-    - name: Run cargo check
-      run: cargo check --all
-
     - name: Run tests
       run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -13,8 +13,16 @@ This project provides an external data loader for Rerun. It is designed to load 
     ```
     cargo build --release
     ```
-2. **Run**: Execute the loader, providing the path to your E57 file.
+2. **Run 1**: Execute the loader, providing the path to your E57 file.
     ```
     export PATH=$PATH:`pwd`/target/release 
     rerun /path/to/your/file.e57
+    ```
+    You can also run rerun, ensure that the built binary is on the PATH and then drag and drop an E57 file in rerun. 
+
+3. **Run 2**: To limit the number of of scans, use the RERUN_E57_DISPLAY_SCANS environment var:
+
+    ```
+    export PATH=$PATH:`pwd`/target/release 
+    RERUN_E57_DISPLAY_SCANS=0,1,5,10 rerun /path/to/your/file.e57
     ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,18 +32,21 @@ struct Args {
         switch,
         description = "optionally mark data to be logged statically"
     )]
+    #[allow(dead_code)]
     static_: bool,
 
     #[argh(
         option,
         description = "optional timestamps to log at (e.g. --time sim_time=1709203426)"
     )]
+    #[allow(dead_code)]
     time: Vec<String>,
 
     #[argh(
         option,
         description = "optional sequences to log at (e.g. --sequence sim_frame=42)"
     )]
+    #[allow(dead_code)]
     sequence: Vec<String>,
 }
 
@@ -180,7 +183,7 @@ fn main() -> Result<()> {
                 format!("{entity_path_prefix}/scan_{index}/point"),
                 &Points3D::new(translation)
                     .with_colors([rerun::Color::from_rgb(255, 0, 0)])
-                    .with_radii([0.15 as f32])
+                    .with_radii([0.15_f32])
                     .with_labels([format!("Scan {index}")])
             )?;
         }
@@ -194,20 +197,17 @@ fn main() -> Result<()> {
                 }
             };
 
-            match p.cartesian {
-                CartesianCoordinate::Valid { x, y, z } => {
-                    buffer.push(Vec3D::new(x as f32, y as f32, z as f32));
-                    let color = match p.color {
-                        Some(color) => rerun::Color::from_rgb(
-                            (color.red * 255.0) as u8,
-                            (color.green * 255.0) as u8,
-                            (color.blue * 255.0) as u8,
-                        ),
-                        _ => rerun::Color::from_rgb(255, 255, 255),
-                    };
-                    color_buffer.push(color)
-                }
-                _ => {}
+            if let CartesianCoordinate::Valid { x, y, z } = p.cartesian {
+                buffer.push(Vec3D::new(x as f32, y as f32, z as f32));
+                let color = match p.color {
+                    Some(color) => rerun::Color::from_rgb(
+                        (color.red * 255.0) as u8,
+                        (color.green * 255.0) as u8,
+                        (color.blue * 255.0) as u8,
+                    ),
+                    _ => rerun::Color::from_rgb(255, 255, 255),
+                };
+                color_buffer.push(color)
             }
 
             if buffer.len() >= chunk_size {


### PR DESCRIPTION
1. Ability to define which scans to display: `RERUN_E57_DISPLAY_SCANS=0,1,5,10 rerun /path/to/your/file.e57`
2. Visual markers placed for scan locations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now supports filtering point cloud scans based on an environment configuration, letting users process only selected scans.

- **Documentation**
  - Updated usage instructions clarify the new step organization, including guidance on limiting scans via an environment variable and using drag-and-drop for file loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->